### PR TITLE
Making app_name and app_text dynamic, not static

### DIFF
--- a/templates/SKTemplate_Multi/Platforms/Android/Resources/values/strings.xml
+++ b/templates/SKTemplate_Multi/Platforms/Android/Resources/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">SKTemplate_Multi</string>
-    <string name="app_text">SKTemplate_Multi</string>
+    <string name="app_name">SKTemplate_Multi.1</string>
+    <string name="app_text">SKTemplate_Multi.1</string>
 </resources>


### PR DESCRIPTION
Making app_name and app_text dynamic (the directory) as is used elsewhere in the template.

Currently when using the "dotnet new sk-multi" template command, the app name is always hardcoded as "SKTemplate_Multi" and shows as this when deployed to the device.

This gets confusing when creating many different projects with sk-multi, causing users to have to manually the strings.xml file each time in order to get the intended app name on the target device when deploying.